### PR TITLE
Fixed POST calls for swagger and http working for Swagger

### DIFF
--- a/static/readme.md
+++ b/static/readme.md
@@ -16,11 +16,8 @@
 - Enter `vagrant up && vagrant ssh`
 - Enter `python /vagrant/server.py`
 - Open your browser and go to [localhost:5000](http://localhost:5000)
-- For *Try it out!* to work, in the `static/swagger/specification/portfolioMgmt.js` file:
-    - Change the line `"host": "portfoliomgmt.mybluemix.net",` to `"host": "localhost:5000",`.
-    - Change the line `"https"` to `"http"`
-- **IMPORTANT**: In order not to go crazy, you should close your browser and restart it so that it actually reloads the updated *js* file.
-Simply refreshing the page will re-use the same *js* specification file and you will not see updated information.
+- For *Try it out!* to work, change the line `"host": "portfoliomgmt.mybluemix.net",` to `"host": "localhost:5000",` in the `static/swagger/specification/portfolioMgmt.js` file.
+- **IMPORTANT**: Your browser caches *js* files so you will have to clean the cache each time you modify Swagger.
 
 ## Test it on Bluemix
 - If not installed, please install the cf cli from [github.com/cloudfoundry/cli](https://github.com/cloudfoundry/cli)

--- a/static/swagger/specification/portfolioMgmt.js
+++ b/static/swagger/specification/portfolioMgmt.js
@@ -8,7 +8,8 @@ var spec =
     },
     "host": "portfoliomgmt.mybluemix.net",
     "schemes": [
-        "https"
+        "https",
+        "http"
     ],
     "basePath": "/api/v1",
     "produces": [
@@ -39,11 +40,17 @@ var spec =
                 "description": "Create a new user portfolio",
                 "parameters": [
                     {
-                        "name": "user",
-                        "in": "query",
+                        "name": "body",
+                        "in": "body",
                         "description": "New user for which a portfolio should be created",
                         "required": true,
-                        "type": "string"
+                        "schema": {
+                            "properties": {
+                                "user": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     }
                 ],
                 "tags": [
@@ -54,7 +61,7 @@ var spec =
                         "description": "Portfolio successfully created"
                     },
                     "400": {
-                        "description": "The query is not well formed (more details in error message)",
+                        "description": "Body is not well formed (more details in error message)",
                         "schema": {
                             "$ref": "#/definitions/error_data"
                         }
@@ -137,18 +144,20 @@ var spec =
                         "type": "string"
                     },
                     {
-                        "name": "asset_id",
-                        "in": "query",
+                        "name": "body",
+                        "in": "body",
                         "description": "The unique asset id of the asset being added to the portfolio",
                         "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "quantity",
-                        "in": "query",
-                        "description": "The quantity of the asset being added to the portfolio",
-                        "required": true,
-                        "type": "integer"
+                        "schema": {
+                            "properties": {
+                                "asset_id": {
+                                    "type": "integer"
+                                },
+                                "quantity": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
                     }
                 ],
                 "tags": [
@@ -159,7 +168,7 @@ var spec =
                         "description": "The asset was added to the portfolio"
                     },
                     "400": {
-                        "description": "Query is not well formed or the asset id does not exist",
+                        "description": "Body is not well formed or the asset id does not exist",
                         "schema": {
                             "$ref": "#/definitions/error_data"
                         }
@@ -239,11 +248,17 @@ var spec =
                         "type": "integer"
                     },
                     {
-                        "name": "quantity",
-                        "in": "query",
+                        "name": "body",
+                        "in": "body",
                         "description": "The quantity to add or subtract from the current quantity of this asset in the portfolio",
                         "required": true,
-                        "type": "integer"
+                        "schema": {
+                            "properties": {
+                                "quantity": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
                     }
                 ],
                 "responses": {
@@ -251,7 +266,7 @@ var spec =
                         "description": "The quantity has been updated successfully"
                     },
                     "400": {
-                        "description": "Query is not well formed (more information in the error message) or the quantity to subtract will yield a negative quantity result (not allowed here).",
+                        "description": "Body is not well formed (more information in the error message) or the quantity to subtract will yield a negative quantity result (not allowed here).",
                         "schema": {
                             "$ref": "#/definitions/error_data"
                         }

--- a/static/swagger/specification/portfolioMgmt.json
+++ b/static/swagger/specification/portfolioMgmt.json
@@ -7,7 +7,8 @@
     },
     "host": "portfoliomgmt.mybluemix.net",
     "schemes": [
-        "https"
+        "https",
+        "http"
     ],
     "basePath": "/api/v1",
     "produces": [
@@ -38,11 +39,17 @@
                 "description": "Create a new user portfolio",
                 "parameters": [
                     {
-                        "name": "user",
-                        "in": "query",
+                        "name": "body",
+                        "in": "body",
                         "description": "New user for which a portfolio should be created",
                         "required": true,
-                        "type": "string"
+                        "schema": {
+                            "properties": {
+                                "user": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     }
                 ],
                 "tags": [
@@ -53,7 +60,7 @@
                         "description": "Portfolio successfully created"
                     },
                     "400": {
-                        "description": "The query is not well formed (more details in error message)",
+                        "description": "Body is not well formed (more details in error message)",
                         "schema": {
                             "$ref": "#/definitions/error_data"
                         }
@@ -136,18 +143,20 @@
                         "type": "string"
                     },
                     {
-                        "name": "asset_id",
-                        "in": "query",
+                        "name": "body",
+                        "in": "body",
                         "description": "The unique asset id of the asset being added to the portfolio",
                         "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "quantity",
-                        "in": "query",
-                        "description": "The quantity of the asset being added to the portfolio",
-                        "required": true,
-                        "type": "integer"
+                        "schema": {
+                            "properties": {
+                                "asset_id": {
+                                    "type": "integer"
+                                },
+                                "quantity": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
                     }
                 ],
                 "tags": [
@@ -158,7 +167,7 @@
                         "description": "The asset was added to the portfolio"
                     },
                     "400": {
-                        "description": "Query is not well formed or the asset id does not exist",
+                        "description": "Body is not well formed or the asset id does not exist",
                         "schema": {
                             "$ref": "#/definitions/error_data"
                         }
@@ -238,11 +247,17 @@
                         "type": "integer"
                     },
                     {
-                        "name": "quantity",
-                        "in": "query",
+                        "name": "body",
+                        "in": "body",
                         "description": "The quantity to add or subtract from the current quantity of this asset in the portfolio",
                         "required": true,
-                        "type": "integer"
+                        "schema": {
+                            "properties": {
+                                "quantity": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
                     }
                 ],
                 "responses": {
@@ -250,7 +265,7 @@
                         "description": "The quantity has been updated successfully"
                     },
                     "400": {
-                        "description": "Query is not well formed (more information in the error message) or the quantity to subtract will yield a negative quantity result (not allowed here).",
+                        "description": "Body is not well formed (more information in the error message) or the quantity to subtract will yield a negative quantity result (not allowed here).",
                         "schema": {
                             "$ref": "#/definitions/error_data"
                         }

--- a/static/swagger/specification/portfolioMgmt.yaml
+++ b/static/swagger/specification/portfolioMgmt.yaml
@@ -6,6 +6,7 @@ info:
 host: portfoliomgmt.mybluemix.net
 schemes:
   - https
+  - http
 basePath: /api/v1
 produces:
   - application/json
@@ -31,18 +32,21 @@ paths:
       summary: Create a new user portfolio
       description: Create a new user portfolio
       parameters:
-        - name: user
-          in: query
+        - name: body
+          in: body
           description: New user for which a portfolio should be created
           required: true
-          type: string
+          schema:
+            properties:
+              user:
+                type: string
       tags:
         - Portfolios
       responses:
         201:
           description: Portfolio successfully created
         400:
-          description: The query is not well formed (more details in error message)
+          description: Body is not well formed (more details in error message)
           schema: {$ref: '#/definitions/error_data'}
         409:
           description: A portfolio for the user already exists
@@ -93,23 +97,23 @@ paths:
           description: Username of portfolio owner
           required: true
           type: string
-        - name: asset_id
-          in: query
+        - name: body
+          in: body
           description: The unique asset id of the asset being added to the portfolio
           required: true
-          type: integer
-        - name: quantity
-          in: query
-          description: The quantity of the asset being added to the portfolio
-          required: true
-          type: integer
+          schema:
+            properties:
+              asset_id:
+                type: integer
+              quantity:
+                type: integer
       tags:
         - Portfolios
       responses:
         201:
           description: The asset was added to the portfolio
         400:
-          description: Query is not well formed or the asset id does not exist
+          description: Body is not well formed or the asset id does not exist
           schema: {$ref: '#/definitions/error_data'}
         404:
           description: User not found or there is no data associated with user
@@ -158,16 +162,19 @@ paths:
           description: The asset id of the asset to update
           required: true
           type: integer
-        - name: quantity
-          in: query
+        - name: body
+          in: body
           description: The quantity to add or subtract from the current quantity of this asset in the portfolio
           required: true
-          type: integer
+          schema:
+            properties:
+              quantity:
+                type: integer
       responses:
         200:
           description: The quantity has been updated successfully
         400:
-          description: Query is not well formed (more information in the error message) or the quantity to subtract will yield a negative quantity result (not allowed here).
+          description: Body is not well formed (more information in the error message) or the quantity to subtract will yield a negative quantity result (not allowed here).
           schema: {$ref : '#/definitions/error_data'}
         404:
           description: User not found, or user data is empty or the asset ID not found in the user portfolio.


### PR DESCRIPTION
Try it out POST calls now work.
The https and http schemes are both supported by API calls made by Swagger.
You can now access Swagger on the Bluemix service with https or http.