### PR TITLE
Added Travis notification for Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,12 @@ after_success:
 
 services:
   - redis-server
+
+notifications:
+  email: false
+  slack:
+    template:
+      - "%{repository}, branch %{branch}, by %{author}) : Commit %{commit_subject}, %{commit_message} "
+      - "Result of build: %{result}; Build details: %{build_url}"
+    rooms:
+      - nyu-devops:PjFNnnnZYQ2rIfnCiIL0RI46#portfolio2


### PR DESCRIPTION
Only modified `.travis.yml` configuration file to notify when a build is executed on Travis CI on the Slack channel.