### PR TITLE
Redirect https bluemix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install: "pip install -r requirements.txt"
 before_script: redis-cli ping
 
 script:
-  - behave
   - nosetests --verbose --with-coverage --cover-erase --cover-package=server
+  - behave
 
 after_success:
   - coveralls

--- a/features/environment.py
+++ b/features/environment.py
@@ -8,7 +8,6 @@ def before_all(context):
     context.server.init_redis(creds.host, creds.port, creds.password)
     context.api_url = context.server.url_version
     context.server.SECURED = False
-    context.server.FORCE_HTTPS = False
 
 def before_scenario(context, scenario):
     context.server.redis_server.flushdb()


### PR DESCRIPTION
- HTTP is redirected to HTTPS only on Bluemix (hopefully)
- HTTP is not redirected to HTTPS on Vagrant (no SSL available)
- Unit tests are ran first before behave on Travis
- No FORCE_HTTPS anymore
- Creating a user now requires to authenticate as an admin; tests updated to work with authentication
- Coverage increased somehow